### PR TITLE
Temporary fix for node20 GLIBC_2.28 version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,9 @@ jobs:
     outputs:
       app-version: ${{ steps.app-version.outputs.version }}
 
+	env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
from https://github.com/s1lentq/reapi/pull/319
